### PR TITLE
[oneshot] Don't launch oneshot during install. Fixes JB#50646

### DIFF
--- a/rpm/gmp-droid.spec
+++ b/rpm/gmp-droid.spec
@@ -34,7 +34,7 @@ echo "%{_libdir}/xulrunner-qt5-%{gecko_ver}/%{name}/0.1/generate-info 1>%{_libdi
 
 %post
 # Query device codec support and write out the droid.info file. On imager this should postpone until first boot.
-%{_bindir}/add-oneshot --now gmp-generate-info.sh
+%{_bindir}/add-oneshot gmp-generate-info.sh
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
Although tested ok on some devices, it seems that the codec querying doesn't work on all devices in system-update mode, and it's not clear why. It would be nice to run this instantly on manual installs, but the possibility of hung upgrades means it should be disabled for now.