### PR TITLE
[gmp-droid] Drop libhybris dependency. JB#54878

### DIFF
--- a/gmp-droid.cpp
+++ b/gmp-droid.cpp
@@ -1007,8 +1007,10 @@ GMPErr GMPInit (GMPPlatformAPI * platformAPI)
 {
   LOG (DEBUG, "Initializing droidmedia!");
   g_platform_api = platformAPI;
-  droid_media_init ();
-  return GMPNoErr;
+  if (droid_media_init ())
+    return GMPNoErr;
+  else
+    return GMPNotImplementedErr;
 }
 
 GMPErr GMPGetAPI (const char *apiName, void *hostAPI, void **pluginApi)

--- a/meson.build
+++ b/meson.build
@@ -10,34 +10,30 @@ cc = meson.get_compiler('c')
 
 root_dir = include_directories('.')
 gmp_api = include_directories('gmp-api')
-droidmedia_h = include_directories('/usr/include/droidmedia')
-hybris_dep = cc.find_library('hybris-common', required: true)
+droidmedia_dep = dependency('droidmedia', required: true)
 
 gmpdroid_install_dir = '/'.join([ get_option('libdir'), meson.project_name(), meson.project_version()])
 
 gmp_source = [
   'gmp-droid.cpp',
   'gmp-droid-conv.cpp',
-  '/usr/share/droidmedia/hybris.c',
   'gmp-task-utils.h',
   'gmp-task-utils-generated.h'
 ]
 
 gmpdroid_lib = shared_library('droid',
                        gmp_source,
-                       include_directories: [ gmp_api, droidmedia_h ],
+                       include_directories: [ gmp_api ],
                        install: true,
-                       dependencies: hybris_dep,
+                       dependencies: droidmedia_dep,
                        install_dir: gmpdroid_install_dir )
 
 info_source = [
   'generate-info.cpp',
-  '/usr/share/droidmedia/hybris.c'
 ]
 
 generate_info = executable('generate-info',
                        info_source,
-                       include_directories: [ droidmedia_h ],
                        install: true,
-                       dependencies: hybris_dep,
+                       dependencies: droidmedia_dep,
                        install_dir: gmpdroid_install_dir )

--- a/rpm/gmp-droid.spec
+++ b/rpm/gmp-droid.spec
@@ -9,9 +9,8 @@ Source1:        gmp-generate-info.sh
 BuildRequires:  meson
 BuildRequires:  ninja
 BuildRequires:  oneshot
-BuildRequires:  pkgconfig(libandroid-properties)
-BuildRequires:  droidmedia-devel
-Requires:       droidmedia
+BuildRequires:  pkgconfig(droidmedia)
+Suggests:       droidmedia
 Requires:  oneshot
 %{_oneshot_requires_post}
 


### PR DESCRIPTION
Link gmp-droid against droidmedia wrapper, so the dependency on
droidmedia becomes weak and the source can be built in a hardware
agnostic project.