### PR TITLE
Use env variable for droidConvert quirk

### DIFF
--- a/gmp-droid-conv.cpp
+++ b/gmp-droid-conv.cpp
@@ -207,8 +207,8 @@ DroidColourConvert::GetConverter (DroidMediaCodecMetaData * md,
   DroidColourConvert *converter;
   *conv_name = "None";
   DroidMediaConvert *droidConvert = droid_media_convert_create ();
-  if (droidConvert) {
-    //TODO: Check DONT_USE_DROID_CONVERT_VALUE quirk. May not be needed.
+
+  if (droidConvert && !std::getenv("GMP_DROID_DONT_USE_DROID_CONVERT")) {
     converter = new ConvertNative (droidConvert);
     *conv_name = "ConvertNative";
   } else {


### PR DESCRIPTION
On at the fxtec pro1, the droidconvert path doesnt work and causes render issues.  Because gmp-droid cannot read files, get the quirk from the environment.  This can be set on a port basis using a file like
/var/lib/environment/nemo/99-quirks.conf 
GMP_DROID_DONT_USE_DROID_CONVERT=1
