### PR TITLE
[gmp-droid] Set up the video encoder to produce CBR stream. JB#57733

### DIFF
--- a/gmp-droid.cpp
+++ b/gmp-droid.cpp
@@ -690,6 +690,7 @@ public:
     m_metadata.stride = codecSettings.mWidth;
     m_metadata.slice_height = codecSettings.mHeight;
     m_metadata.meta_data = false;
+    m_metadata.bitrate_mode = DROID_MEDIA_CODEC_BITRATE_CONTROL_CBR;
 
     droid_media_colour_format_constants_init (&m_constants);
     m_metadata.color_format = -1;


### PR DESCRIPTION
Set up the video encoder to produce a constant bitrate stream because
the VBR stream that is generated by default conflicts with internal
WebRTC bandwidth limiting algorithms.